### PR TITLE
add linear least squares problem + small reorg

### DIFF
--- a/benchmarx/__init__.py
+++ b/benchmarx/__init__.py
@@ -1,0 +1,1 @@
+from benchmarx.benchmark import Benchmark

--- a/benchmarx/_problems/lls.py
+++ b/benchmarx/_problems/lls.py
@@ -1,0 +1,154 @@
+from benchmarx.problem import Problem
+from benchmarx.defaults import default_seed
+import jax.numpy as jnp
+from jax import random
+import logging
+from sklearn.datasets import load_wine
+import pandas as pd
+
+class LinearLeastSquares(Problem):
+    """
+    A class describing an unconstrained linear least squares problem.
+
+    f(x) = 1/2*||Ax - b||_2^2 -> min_x
+
+    Typical usage example:
+
+    problem = LinearLeastSquares("random", m=3, n=3)
+    benchmark = Benchmark(problem=problem, ...)
+    result = benchmark.run()
+    """
+
+    def __init__(self, problem_type: str, 
+        A: jnp.array=None, b: jnp.array=None, x_opt: jnp.array=None, 
+        m: int=None, n: int=None, seed: int=default_seed,
+        reduce: bool=False) -> None:
+        """
+        Initializes the LinearLeastSquares problem.
+
+        Args:
+            problem_type: The type of problem to set up. Can be one of the
+                               following:
+                               - 'random'
+                               - 'boston'
+                               - 'wine'
+                               - 'custom'
+            A (optional): Matrix A for the custom problem. Defaults to None.
+            b (optional): Vector b for the custom problem. Defaults to None.
+            x_opt(optional): Optimal solution for the custom problem. 
+                                Defaults to None.
+            m (optional): Dimension of the data for random types. 
+                               Defaults to None.
+            n (optional): Dimension of the problem for random types. 
+                               Defaults to None.
+            seed (optional): Seed for RNG. Defaults to benchmarx 
+                                default_seed.
+        Raises:
+            ValueError: If the provided problem_type is not recognized.
+            ValueError: If required parameters (A, b for 'custom', 
+                m, n for 'random') are not provided.
+        """
+        super().__init__(
+            info=f"Linear Least Squares problem on {problem_type} dataset", 
+            func=self.f
+            )
+
+        self.seed = seed
+        self.reduce = reduce
+
+        if problem_type == 'custom':
+            if A is None or b is None:
+                raise ValueError("For custom problem type, "
+                    "A and b must be provided.")
+            self.A = A
+            self.b = b
+            if x_opt is None:
+                logging.debug("Solving custom linear system with "
+                                "jnp.linalg.lstsq ")
+                self.x_opt = jnp.linalg.lstsq(A, b)[0]
+            else:
+                self.x_opt = x_opt
+
+        elif problem_type == 'random':
+            if m is None or n is None:
+                raise ValueError("For random problem types, "
+                    "m and n must be provided.")
+            self.A, self.b, self.x_opt = self._generate_data(m, n)
+        elif problem_type in ['boston', 'wine']:
+            self.A, self.b, self.x_opt = self._load_data(problem_type)
+        else:
+            raise ValueError(f"Unknown problem type: {problem_type}")
+        
+    def _generate_data(self, m, n):
+        """
+        Generates random data for the linear system.
+
+        Args:
+            m (int): Dimension of the data.
+            n (int): Dimension of the problem.
+
+        Returns:
+            A: Matrix A for the problem.
+            b: Vector b for the problem.
+            x_opt: Optimal solution for the problem
+        """
+
+        # Log system type
+        if m < n:
+            logging.debug("Generating underdetermined system.")
+        elif m == n:
+            logging.debug("Generating square system.")
+        elif m > n:
+            logging.debug("Generating overdetermined system.")
+
+        RNG = random.PRNGKey(self.seed)
+
+        A = random.normal(RNG, (m, n))
+        x_opt = random.normal(RNG, (n,))
+        b = jnp.dot(A, x_opt)
+
+        return A, b, x_opt
+
+    def _load_data(self, problem_type):
+        """
+        Loads problem data from available datasets.
+
+        Args:
+            problem_type (str): Name of the dataset to load.
+
+        Returns:
+            A (jnp.array): Matrix A for the problem.
+            b (jnp.array): Vector b for the problem.
+            x_opt (jnp.array): Optimal solution vector.
+        """
+        if problem_type == 'boston':
+            data_url = "http://lib.stat.cmu.edu/datasets/boston"
+            raw_df = pd.read_csv(data_url, sep="\s+", skiprows=22,header=None)
+            data = jnp.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])
+            target = raw_df.values[1::2, 2]
+            logging.debug("Loading boston house-prices datase")
+            A = data
+            b = target
+        elif problem_type == 'wine':
+            logging.debug("Loading Wine dataset")
+            data = load_wine()
+            A = data.data
+            b = data.target
+        else:
+            raise ValueError(f"Unknown dataset name: {problem_type}")
+
+        # Compute optimal solution using least squares
+        x_opt = jnp.linalg.lstsq(A, b)[0]
+
+        return A, b, x_opt
+
+    def f(self, x: jnp.array, *args, **kwargs):
+        """
+        Function to minimize.
+        """
+        x = jnp.array(x)
+        if self.reduce:
+            m, n = self.A.shape 
+            return 1/(2*m)*jnp.linalg.norm(self.A@x - self.b)**2
+        else:
+            return 0.5*jnp.linalg.norm(self.A@x - self.b)**2

--- a/benchmarx/problems.py
+++ b/benchmarx/problems.py
@@ -1,0 +1,1 @@
+from benchmarx._problems.lls import LinearLeastSquares

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,5 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname("benchmarx"), '..')))
+
+import benchmarx

--- a/tests/test_lls.py
+++ b/tests/test_lls.py
@@ -1,0 +1,35 @@
+import pytest
+from context import benchmarx
+
+from benchmarx.problems import LinearLeastSquares
+import jax.numpy as jnp
+import jax
+
+def test_custom_problem():
+    A = jnp.array([[1.0, 0.0], [0.0, 1.0]])
+    b = jnp.array([1.0, 2.0])
+
+    problem = LinearLeastSquares("custom", A=A, b=b)
+    x = jax.random.normal(jax.random.PRNGKey(0), (2,))
+
+    assert problem.f(x) >= 0.0
+
+def test_random_problem():
+    problem = LinearLeastSquares("random", m=2, n=2)
+    x = jax.random.normal(jax.random.PRNGKey(0), (2,))
+
+    assert problem.f(x) >= 0.0
+
+def test_boston_problem():
+    problem = LinearLeastSquares("boston")
+    m, n = problem.A.shape
+    x = jax.random.normal(jax.random.PRNGKey(0), (n,))
+
+    assert problem.f(x) >= 0.0
+
+def test_wine_problem():
+    problem = LinearLeastSquares("wine")
+    m, n = problem.A.shape
+    x = jax.random.normal(jax.random.PRNGKey(0), (n,))
+
+    assert problem.f(x) >= 0.0


### PR DESCRIPTION
I've added:
* linear least squares problem class with an ability to load boston dataset, wine dataset and custom dataset
* basic tests for it as an example of future tests to be written
* small reorganization of problems.py file, which will include all problems in order to import them as `from benchmarx.problems import LinearLeastSquares`
